### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Bunk-o-Meter
 ============
 
-#####Update: It's been 2.5 years since I wrote this app. Please avoid going through the project files. The code is really embarassing :P
+##### Update: It's been 2.5 years since I wrote this app. Please avoid going through the project files. The code is really embarassing :P
 
 About
 --------------


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
